### PR TITLE
Fixed comment model validation issue

### DIFF
--- a/comments/models/Comments_CommentModel.php
+++ b/comments/models/Comments_CommentModel.php
@@ -53,17 +53,19 @@ class Comments_CommentModel extends BaseElementModel
             $this->addError('comment', Craft::t('Comment blocked due to security policy.'));
         }
 
-        // Protect against Anonymous submissions, if turned off
-        if (!$settings->allowAnonymous && !$this->userId) {
-            $this->addError('comment', Craft::t('Must be logged in to comment.'));
-
-            // Additionally, check for user email/name, which is compulsary for guests
+        if ($settings->allowAnonymous) {
+            // Check for user email/name, which is compulsary for guests
             if (!$this->name) {
                 $this->addError('name', Craft::t('Name is required.'));
             }
 
             if (!$this->email) {
                 $this->addError('email', Craft::t('Email is required.'));
+            }
+        } else {
+            // Protect against Anonymous submissions, if turned off
+            if (!$this->userId) {
+                $this->addError('comment', Craft::t('Must be logged in to comment.'));
             }
         }
 


### PR DESCRIPTION
Prior to this modification, it was possible for anonymous users to create comments without the required name and email fields. The invalid data ended up causing an error while trying to render the comment using the default templates.