### PR TITLE
commentDate field; structure cleanup on uninstall; fk between comments and elements

### DIFF
--- a/comments/CommentsPlugin.php
+++ b/comments/CommentsPlugin.php
@@ -14,12 +14,12 @@ class CommentsPlugin extends BasePlugin
 
     public function getVersion()
     {
-        return '0.4.9';
+        return '0.5.0';
     }
 
     public function getSchemaVersion()
     {
-        return '1.0.0';
+        return '1.0.5.0';
     }
 
     public function getDeveloper()
@@ -110,6 +110,9 @@ class CommentsPlugin extends BasePlugin
 
     public function onAfterInstall()
     {
+
+    	parent::onAfterInstall();
+
         // Comments are a Structure, which helps with hierarchy-goodness.
         // We only use a single structure for all our comments so store this at the plugin settings level
         if (!$this->getSettings()->structureId) {
@@ -120,9 +123,22 @@ class CommentsPlugin extends BasePlugin
             // Update our plugin settings straight away!
             craft()->plugins->savePluginSettings($this, array('structureId' => $structure->id));
         }
+
     }
 
-    public function init()
+    public function onBeforeUninstall()
+	{
+
+		parent::onBeforeUninstall();
+
+		// Delete the Comments structure
+		if ($this->getSettings()->structureId) {
+			craft()->structures->deleteStructureById($this->getSettings()->structureId);
+		}
+
+	}
+
+	public function init()
     {
         // Only used on the /comments page, hook onto the 'cp.elements.element' hook to allow us to
         // modify the Title column for the element index table - we want something special.

--- a/comments/elementtypes/Comments_CommentElementType.php
+++ b/comments/elementtypes/Comments_CommentElementType.php
@@ -76,7 +76,7 @@ class Comments_CommentElementType extends BaseElementType
     {
         return array(
             'comment'       => Craft::t('Comment'),
-            'dateCreated'   => Craft::t('Date'),
+            'commentDate'   => Craft::t('Date'),
             'elementId'     => Craft::t('Element'),
         );
     }
@@ -86,7 +86,7 @@ class Comments_CommentElementType extends BaseElementType
         return array(
             'status'        => Craft::t('Status'),
             'comment'       => Craft::t('Comment'),
-            'dateCreated'   => Craft::t('Date'),
+            'commentDate'   => Craft::t('Date'),
             'elementId'     => Craft::t('Element'),
         );
     }
@@ -123,6 +123,7 @@ class Comments_CommentElementType extends BaseElementType
             'ipAddress'     => array(AttributeType::String),
             'userAgent'     => array(AttributeType::String),
             'comment'       => array(AttributeType::Mixed),
+			'commentDate'   => array(AttributeType::DateTime),
             'order'         => array(AttributeType::String, 'default' => 'lft, commentDate desc'),
         );
     }
@@ -130,7 +131,7 @@ class Comments_CommentElementType extends BaseElementType
     public function modifyElementsQuery(DbCommand $query, ElementCriteriaModel $criteria)
     {
         $query
-        ->addSelect('comments.elementId, comments.userId, comments.elementType, comments.structureId, comments.status, comments.name, comments.email, comments.url, comments.ipAddress, comments.userAgent, comments.comment, comments.dateCreated AS commentDate')
+        ->addSelect('comments.elementId, comments.userId, comments.elementType, comments.structureId, comments.status, comments.name, comments.email, comments.url, comments.ipAddress, comments.userAgent, comments.comment, comments.commentDate, comments.dateCreated')
         ->join('comments comments', 'comments.id = elements.id')
         ->leftJoin('comments_votes comments_votes', 'comments_votes.commentId = comments.id')
         ->leftJoin('structures structures', 'structures.id = comments.structureId')

--- a/comments/migrations/m171130_000000_comments_addCommentDateColumn.php
+++ b/comments/migrations/m171130_000000_comments_addCommentDateColumn.php
@@ -1,0 +1,28 @@
+<?php
+namespace Craft;
+
+/**
+ * @author Michael Rog <michael@michaelrog.com>
+ */
+class m171130_000000_comments_addCommentDateColumn extends BaseMigration
+{
+
+	public function safeUp()
+	{
+
+		/*
+		 * First create the new column
+		 */
+		$this->addColumnAfter('comments', 'commentDate', ColumnType::DateTime, 'comment');
+
+		/*
+		 * For existing records, backfill the new column with the existing values from dateCreated
+		 */
+		$table = craft()->db->addTablePrefix('comments');
+		$this->execute("update {$table} set commentDate = dateCreated;");
+
+		return true;
+
+	}
+
+}

--- a/comments/migrations/m171130_000000_comments_addElementForeignKey.php
+++ b/comments/migrations/m171130_000000_comments_addElementForeignKey.php
@@ -1,0 +1,48 @@
+<?php
+namespace Craft;
+
+/**
+ * @author Michael Rog <michael@michaelrog.com>
+ */
+class m171130_000000_comments_addElementForeignKey extends BaseMigration
+{
+
+	public function safeUp()
+	{
+
+		/*
+		 * The `id` of each Comment record should be tied to the corresponding Element record,
+		 * so that when Elements are deleted by Craft - i.e. in `CommentsService:deleteComment()` -
+		 * the associated Comments records will be deleted by cascade. Otherwise orphans will be left in the `comments` table.
+		 */
+
+		/*
+		 * Adding a foreign key will fail if we already have orphan records in the `comments` table.
+		 * So, first, we must delete all the Comment records that don't have an associated Element record anymore.
+		 */
+
+		// Get the IDs of any orphaned comments...
+		$ids = craft()->db->createCommand()
+			->select('c.id')
+			->from('comments c')
+			->leftJoin('elements e', 'c.id = e.id')
+			->where('e.id is null')
+			->queryColumn();
+
+		// ...and nuke 'em.
+		if ($ids)
+		{
+			$this->delete('comments', array('in', 'id', $ids));
+		}
+
+		/*
+		 * Now we can safely add the FK.
+		 */
+
+		craft()->db->createCommand()->addForeignKey('comments', 'id', 'elements', 'id', 'CASCADE', null);
+
+		return true;
+
+	}
+
+}

--- a/comments/models/Comments_CommentModel.php
+++ b/comments/models/Comments_CommentModel.php
@@ -309,6 +309,7 @@ class Comments_CommentModel extends BaseElementModel
             'ipAddress'     => array(AttributeType::String),
             'userAgent'     => array(AttributeType::String),
             'comment'       => array(AttributeType::String),
+			'commentDate'   => array(AttributeType::DateTime),
 
             // Just used for saving
             'parentId'      => AttributeType::Number,

--- a/comments/records/Comments_CommentRecord.php
+++ b/comments/records/Comments_CommentRecord.php
@@ -21,10 +21,26 @@ class Comments_CommentRecord extends BaseRecord
     public function defineRelations()
     {
         return array(
-            'element'  => array(static::BELONGS_TO, 'ElementRecord', 'required' => true, 'onDelete' => static::CASCADE),
+			'element'  => array(static::BELONGS_TO, 'ElementRecord', 'id', 'required' => true, 'onDelete' => static::CASCADE),
+			'parentElement'  => array(static::BELONGS_TO, 'ElementRecord', 'elementId', 'required' => true, 'onDelete' => static::CASCADE),
             'user' => array(static::BELONGS_TO, 'UserRecord', 'onDelete' => static::CASCADE),
         );
     }
+
+	/**
+	 * Prepares the model's attribute values to be saved to the database.
+	 *
+	 * @return null
+	 */
+	public function prepAttributesForSave()
+	{
+		parent::prepAttributesForSave();
+		// Populate commentDate if this is a new record
+		if ($this->isNewRecord() && empty($this->commentDate))
+		{
+			$this->commentDate = DateTimeHelper::currentTimeForDb();
+		}
+	}
     
 
     // Protected Methods
@@ -47,6 +63,7 @@ class Comments_CommentRecord extends BaseRecord
             'ipAddress'     => array(AttributeType::String),
             'userAgent'     => array(AttributeType::String),
             'comment'       => array(AttributeType::Mixed),
+            'commentDate'   => array(AttributeType::DateTime),
         );
     }
 }


### PR DESCRIPTION
- Separate `commentDate` into its own field rather than deriving it from `dateCreated` (#81). 
- Add event listener to clean up structure on uninstall (#82). 
- Add foreign key so CommentRecords will track their associated ElementRecords (#83).