### PR TITLE
Use Craft's date utilities for getting translatable time diff

### DIFF
--- a/src/elements/Comment.php
+++ b/src/elements/Comment.php
@@ -320,7 +320,8 @@ class Comment extends Element
 
     public function getTimeAgo()
     {
-        return (new Carbon($this->commentDate->format('c')))->diffForHumans();
+        $diff = (new \DateTime())->diff($this->commentDate);
+        return DateTimeHelper::humanDurationFromInterval($diff);
     }
 
     public function isGuest()


### PR DESCRIPTION
Carbon library is cool, but time keywords can't be translated using Craft's translation tools. This way we get rid of `Carbon` dependency and get translation ability instead.