### PR TITLE
Prevent only whitespace being submit

### DIFF
--- a/src/elements/Comment.php
+++ b/src/elements/Comment.php
@@ -575,7 +575,7 @@ class Comment extends Element
 
 
         // Must have an actual comment
-        if (!$this->comment) {
+        if (!trim($this->comment)) {
             $this->addError('comment', Craft::t('comments', 'Comment must not be blank.'));
         }
 


### PR DESCRIPTION
A minor fix to prevent users from submitting space (blank) comment. I am aware this doesn't cover naughty strings as I was not sure this complexity should be introduced here. Therefore, I kept it clean and simple.

With `trim()` most user entered characters are covered. 