### PR TITLE
Add support for max length

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -31,6 +31,7 @@ return [
 
         // Security
         'enableSpamChecks' => true,
+        'securityMaxLength' => '',
         'securityFlooding' => '',
         'securityModeration' => '',
         'securityBlacklist' => '',
@@ -62,6 +63,7 @@ return [
 - `outputDefaultJs` - Whether to output the default JS for the form.
 - `templateFolderOverride` - Provide a path to your own templates in the below folder.
 - `enableSpamChecks` - Whether to enable spam checks for comments.
+- `securityMaxLength` - The maximum number of characters a single comment can have. 
 - `securityFlooding` - The number of seconds between commenting.
 - `securityModeration` - A collection of words that if entered require comments to be moderated.
 - `securityBlacklist` - A collection of words that if entered mark comments as spam.

--- a/src/elements/Comment.php
+++ b/src/elements/Comment.php
@@ -552,6 +552,13 @@ class Comment extends Element
             $this->addError('comment', Craft::t('comments', 'Comment blocked due to security policy.'));
         }
 
+        // Check the maximum comment length.
+        if (!Comments::$plugin->getSecurity()->checkCommentLength($this)) {
+            $this->addError('comment', Craft::t('comments', 'Comment must be shorter than {limit} characters.', [
+                'limit' => $settings->securityMaxLength,
+            ]));
+        }
+
         // Protect against Anonymous submissions, if turned off
         if (!$settings->allowAnonymous && !$this->userId) {
             $this->addError('comment', Craft::t('comments', 'Must be logged in to comment.'));
@@ -719,7 +726,7 @@ class Comment extends Element
         switch ($attribute) {
             case 'ownerId': {
                 $owner = $this->getOwner();
-                
+
                 if ($owner) {
                     return "<a href='" . $owner->cpEditUrl . "'>" . $owner->title . "</a>";
                 } else {

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -43,6 +43,7 @@ class Settings extends Model
     public $recaptchaEnabled = false;
     public $recaptchaKey;
     public $recaptchaSecret;
+    public $securityMaxLength;
     public $securityFlooding;
     public $securityModeration;
     public $securityBlacklist;

--- a/src/services/SecurityService.php
+++ b/src/services/SecurityService.php
@@ -58,6 +58,24 @@ class SecurityService extends Component
         return true;
     }
 
+    public function checkCommentLength(Comment $comment)
+    {
+        $settings = Comments::$plugin->getSettings();
+        // Check if max comment length is set.
+        if ($settings->securityMaxLength) {
+            // Check if the input is a positive integer
+            if (is_numeric($settings->securityMaxLength)
+                && $settings->securityMaxLength > 0
+                && $settings->securityMaxLength == round($settings->securityMaxLength, 0)
+            ) {
+                if (strlen($comment->getComment()) >= (int)$settings->securityMaxLength) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
 
     // Private Methods
     // =========================================================================

--- a/src/templates/settings/_panes/security.html
+++ b/src/templates/settings/_panes/security.html
@@ -42,6 +42,17 @@
 <hr>
 
 {{ forms.textField({
+first: true,
+label: 'Maximum comment length' | t('comments'),
+instructions: 'Limit the number of characters a comment can have.' | t('comments'),
+name: 'securityMaxLength',
+value: settings.securityMaxLength,
+warning: macros.configWarning('securityMaxLength', 'comments'),
+}) }}
+
+<hr>
+
+{{ forms.textField({
     first: true,
     label: 'Minimum time between comments' | t('comments'),
     instructions: 'The number of seconds between commenting. Helps to prevent comment flooding.' | t('comments'),


### PR DESCRIPTION
This PR add additional functionality to the comments. Allow admins to set a limit of characters for a comment. It will return an appropriate error with the allowed characters.

I separated the logic to be in a separate function `checkCommentLength` because the function for checking security (`checkSecurityPolicy`) only return a boolean value, based on this it throws a generic error. Separating this in its own function we can return a more user friendly error which also include the limit.

As we can't trust the admin I added a simple check for the input that it is a valid **positive integer**. So, values that are `0` or below will be ignored (_request won't be checked_) as will characters.

Closes #98 