### PR TITLE
Fix subscribe to singular comment notifications

### DIFF
--- a/src/templates/_special/comment.html
+++ b/src/templates/_special/comment.html
@@ -93,7 +93,7 @@
                         </span>
                     {% endif %}
 
-                    {% if currentUser and settings.notificationSubscribeEnabled %}
+                    {% if currentUser and settings.notificationSubscribeCommentEnabled %}
                         {% set subscribed = craft.comments.isSubscribed(comment.owner, comment) %}
 
                         <span class="cc-ll-i">


### PR DESCRIPTION
The wrong conditional is being tested for allowing subscription to notifications on individual comments. 

It should be _notificationSubscribe**Comment**Enabled_ instead of _notificationSubscribeEnabled_.