### PR TITLE
Don’t show settings to non-admins

### DIFF
--- a/src/templates/_layouts/index.html
+++ b/src/templates/_layouts/index.html
@@ -2,7 +2,7 @@
 
 {% do view.registerAssetBundle('verbb\\comments\\assetbundles\\AdminAsset') %}
 
-{% if noTabs is not defined %}
+{% if noTabs is not defined and currentUser.admin %}
     {% set tabs = {
         comments: { label: 'Comments' | t('comments'), url: url('comments') },
         settings: { label: 'Settings' | t('comments'), url: url('comments/settings') },

--- a/src/templates/settings/index.html
+++ b/src/templates/settings/index.html
@@ -1,3 +1,5 @@
+{% requireAdmin %}
+
 {% extends 'comments/_layouts' %}
 {% import '_includes/forms' as forms %}
 


### PR DESCRIPTION
Currently the settings tab is shown all the time. But non-admins can't change anything. This pull request hides the tab and make sure that non-admins can open the settings page directly.