### PR TITLE
Normalize selector usage in javascript to simplify front-end template customization

### DIFF
--- a/examples/html/form.html
+++ b/examples/html/form.html
@@ -1,6 +1,6 @@
 {% macro errorList(errors) %}
     {% if errors %}
-        <div class="cc-e">
+        <div data-role="errors" class="cc-e"></div>
             {% for error in errors %}
                 {{ error }}
             {% endfor %}

--- a/examples/html/form.html
+++ b/examples/html/form.html
@@ -1,6 +1,6 @@
 {% macro errorList(errors) %}
     {% if errors %}
-        <div data-role="errors" class="cc-e"></div>
+        <div data-role="errors" class="cc-e">
             {% for error in errors %}
                 {{ error }}
             {% endfor %}

--- a/src/resources/src/js/comments.js
+++ b/src/resources/src/js/comments.js
@@ -123,7 +123,7 @@ Comments.Base = Base.extend({
     },
 
     clearNotifications: function($element) {
-        var $elements = $element.querySelectorAll('.cc-e, [data-role="notice"], [data-role="errors"]');
+        var $elements = $element.querySelectorAll('[data-role="notice"], [data-role="errors"]');
 
         if ($elements) {
             Array.prototype.forEach.call($elements, function(el, i) {
@@ -613,7 +613,7 @@ Comments.EditForm = Comments.Base.extend({
 
         // Clear and update
         form.querySelector('[name="fields[comment]"]').innerHTML = this.commentText;
-        form.querySelector('.cc-f-btn').innerHTML = this.t('save');
+        form.querySelector('[type="submit"]').innerHTML = this.t('save');
 
         // Set the value to be the id of comment we're replying to
         (form.querySelector('input[name="commentId"]') || {}).value = this.comment.commentId;

--- a/src/templates/_special/_includes/form.html
+++ b/src/templates/_special/_includes/form.html
@@ -37,12 +37,12 @@
                 <div class="cc-f-row">
                     <div class="cc-f-col">
                         <input class="cc-f-input" name="fields[name]" type="text" placeholder="{{ 'Your name' | t('comments') }}">
-                        <div class="cc-e"></div>
+                        <div data-role="errors" class="cc-e"></div>
                     </div>
 
                     <div class="cc-f-col">
                         <input class="cc-f-input" name="fields[email]" type="email" placeholder="{{ 'Your email' | t('comments') }}">
-                        <div class="cc-e"></div>
+                        <div data-role="errors" class="cc-e"></div>
                     </div>
                 </div>
             {% endif %}

--- a/src/templates/_special/form-fields/elements/comment.html
+++ b/src/templates/_special/form-fields/elements/comment.html
@@ -11,4 +11,4 @@
 {% endif %}
 
 <textarea class="cc-f-textarea" name="fields[comment]" placeholder="{{ instructions }}" {% if required %}required{% endif %}></textarea>
-<div class="cc-e"></div>
+<div data-role="errors" class="cc-e"></div>

--- a/src/templates/_special/form-fields/field.html
+++ b/src/templates/_special/form-fields/field.html
@@ -20,4 +20,4 @@
 
 {{ commentsInclude(['form-fields/fields/' ~ type, 'form-fields/fields/plain-text'], { field: field, required: required }, false, true) }}
 
-<div class="cc-e"></div>
+<div data-role="errors" class="cc-e"></div>


### PR DESCRIPTION
I was about to add a feature request for this, but said fork it.

---

**The Request:**

I'm working on building a custom comments template, and want to utilize the plugin's javascript, but none of its styles. I find it much easier to work with my own classes, and am styling from scratch.

It seems that elements are being selected based on combination of data attributes, classes, and field name attributes.

I think it'd be easier for people to customize templates if they didn't have to worry about class names, as it isn't clear what classes need to persist for the script to function correctly. Moving to using data/name attributes across the board would make things more consistent, and thus easier to customize.

---

_This is untested!_

I was unsure how the following was used, so it'll still need to be updated.
`this.remove(form.querySelector('.cc-i-figure'));`

Looks like there are a couple instances of this class, but I can't tell how it's being affected, or if all instances need to behave similarly.

