### PR TITLE
Support GraphQL mutations

### DIFF
--- a/docs/developers/graphql.md
+++ b/docs/developers/graphql.md
@@ -145,6 +145,24 @@ Narrows the query results based on the comments’ email.
 #### The `comment` argument
 Narrows the query results based on the comments’ actual comment text.
 
+### Custom Fields
+
+If you’ve added custom fields to your Comments Form (**Comments** → **Settings** → **Comments Form** → **Form Layout**), you can query them by handle within a GraphQL fragment. If you added a `summary` Plain Text field, for example, your query might look like this:
+
+```graphql
+{
+    comments (ownerId: 2460, limit: 2, orderBy: "commentDate DESC") {
+        commentDate @formatDateTime (format: "Y-m-d")
+        name
+        email
+        comment
+        ... on Comment {
+            summary
+        }
+    }
+}
+```
+
 ## Mutations
 
 ### createComment

--- a/docs/developers/graphql.md
+++ b/docs/developers/graphql.md
@@ -275,7 +275,7 @@ Query variables:
 
 ### subscribeComment
 
-Subscribe to a comment thread to get notifications:
+Subscribe to an element’s comment notifications:
 
 ```graphql
 mutation SubscribeComment($ownerId: ID!) {
@@ -283,11 +283,32 @@ mutation SubscribeComment($ownerId: ID!) {
 }
 ```
 
+Repeat to toggle on/off.
+
 Query variables:
 
 ```json
 {
   "ownerId": 34
+}
+```
+
+Subscribe to a specific comment thread, where `commentId` is the beginning of that thread:
+
+```graphql
+mutation SubscribeThread($ownerId: ID!, $commentId: ID) {
+    subscribeComment(ownerId: $ownerId, commentId: $commentId)
+}
+```
+
+Repeat to toggle on/off.
+
+Query variables:
+
+```json
+{
+  "ownerId": 34,
+  "commentId": 95
 }
 ```
 

--- a/docs/developers/graphql.md
+++ b/docs/developers/graphql.md
@@ -144,3 +144,167 @@ Narrows the query results based on the comments’ email.
 
 #### The `comment` argument
 Narrows the query results based on the comments’ actual comment text.
+
+## Mutations
+
+### createComment
+
+Saves a new nested visitor comment.
+
+```graphql
+mutation NewComment($newParentId: ID, $ownerId: ID, $name: String, $email: String, $comment: String) {
+  saveComment(newParentId: $newParentId, ownerId: $ownerId, name: $name, email: $email, comment: $comment) {
+    id
+    ownerId
+    name
+    email
+    comment
+  }
+}
+```
+
+Query variables:
+
+```json
+{
+  "ownerId": 7,
+  "newParentId": 30,
+  "name": "Matt",
+  "email": "matt@pixelandtonic.com",
+  "comment": "Here’s a nested comment."
+}
+```
+
+### saveComment
+
+Edit an existing comment.
+
+```graphql
+mutation UpdateComment($id: ID, $comment: String) {
+  saveComment(id: $id, comment: $comment) {
+    id
+    ownerId
+    name
+    email
+    comment
+  }
+}
+```
+
+Query variables:
+
+```json
+{
+  "id": 34,
+  "comment": "I’m totally changing what I said."
+}
+```
+
+### voteComment
+
+Upvote a comment:
+
+```graphql
+mutation UpvoteComment($id: ID, $comment: String) {
+  voteComment(id: $id, comment: $comment) {
+    id
+    ownerId
+    name
+    email
+    comment
+  }
+}
+```
+
+Query variables:
+
+```json
+{
+  "id": 34,
+  "upvote": true
+}
+```
+
+Downvote a comment:
+
+```graphql
+mutation DownvoteComment($id: ID, $comment: String) {
+  voteComment(id: $id, comment: $comment) {
+    id
+    ownerId
+    name
+    email
+    comment
+  }
+}
+```
+
+Query variables:
+
+```json
+{
+  "id": 34,
+  "downvote": true
+}
+```
+
+### flagComment
+
+Flag a comment for moderation:
+
+```graphql
+mutation FlagComment($id: ID!) {
+    flagComment(id: $id) {
+        id
+        comment {
+            flags
+            upvotes
+            downvotes
+        }
+    }
+}
+```
+
+Query variables:
+
+```json
+{
+  "id": 34
+}
+```
+
+### subscribeComment
+
+Subscribe to a comment thread to get notifications:
+
+```graphql
+mutation SubscribeComment($ownerId: ID!) {
+    subscribeComment(ownerId: $ownerId)
+}
+```
+
+Query variables:
+
+```json
+{
+  "ownerId": 34
+}
+```
+
+### deleteComment
+
+Delete a comment:
+
+```graphql
+mutation DeleteComment($id: ID!) {
+    deleteComment(id: $id)
+}
+```
+
+Query variables:
+
+```json
+{
+  "id": 34
+}
+```

--- a/src/Comments.php
+++ b/src/Comments.php
@@ -6,6 +6,7 @@ use verbb\comments\elements\Comment;
 use verbb\comments\fields\CommentsField;
 use verbb\comments\fieldlayoutelements\CommentsField as CommentsFieldLayoutElement;
 use verbb\comments\gql\interfaces\CommentInterface;
+use verbb\comments\gql\interfaces\Vote;
 use verbb\comments\gql\queries\CommentQuery;
 use verbb\comments\gql\mutations\Comment as CommentMutations;
 use verbb\comments\helpers\ProjectConfigData;

--- a/src/Comments.php
+++ b/src/Comments.php
@@ -1,7 +1,6 @@
 <?php
 namespace verbb\comments;
 
-use craft\events\RegisterGqlMutationsEvent;
 use verbb\comments\base\PluginTrait;
 use verbb\comments\elements\Comment;
 use verbb\comments\fields\CommentsField;
@@ -26,6 +25,7 @@ use craft\events\PluginEvent;
 use craft\events\RebuildConfigEvent;
 use craft\events\RegisterComponentTypesEvent;
 use craft\events\RegisterEmailMessagesEvent;
+use craft\events\RegisterGqlMutationsEvent;
 use craft\events\RegisterGqlQueriesEvent;
 use craft\events\RegisterGqlSchemaComponentsEvent;
 use craft\events\RegisterGqlTypesEvent;
@@ -48,7 +48,6 @@ use craft\web\UrlManager;
 use craft\web\twig\variables\CraftVariable;
 
 use yii\base\Event;
-use yii\web\User;
 
 use craft\feedme\events\RegisterFeedMeElementsEvent;
 use craft\feedme\services\Elements as FeedMeElements;
@@ -413,11 +412,11 @@ class Comments extends Plugin
             });
         }
     }
+
     private function _registerWidgets()
     {
         Event::on(Dashboard::class, Dashboard::EVENT_REGISTER_WIDGET_TYPES, function(RegisterComponentTypesEvent $event) {
             $event->types[] = CommentsWidget::class;
         });
     }
-
 }

--- a/src/Comments.php
+++ b/src/Comments.php
@@ -1,12 +1,14 @@
 <?php
 namespace verbb\comments;
 
+use craft\events\RegisterGqlMutationsEvent;
 use verbb\comments\base\PluginTrait;
 use verbb\comments\elements\Comment;
 use verbb\comments\fields\CommentsField;
 use verbb\comments\fieldlayoutelements\CommentsField as CommentsFieldLayoutElement;
 use verbb\comments\gql\interfaces\CommentInterface;
 use verbb\comments\gql\queries\CommentQuery;
+use verbb\comments\gql\mutations\Comment as CommentMutations;
 use verbb\comments\helpers\ProjectConfigData;
 use verbb\comments\integrations\CommentFeedMeElement;
 use verbb\comments\models\Settings;
@@ -313,11 +315,24 @@ class Comments extends Plugin
             }
         });
 
+        Event::on(Gql::class, Gql::EVENT_REGISTER_GQL_MUTATIONS, function(RegisterGqlMutationsEvent $event) {
+            $event->mutations = array_merge(
+                $event->mutations,
+                CommentMutations::getMutations()
+            );
+        });
+
         Event::on(Gql::class, Gql::EVENT_REGISTER_GQL_SCHEMA_COMPONENTS, function(RegisterGqlSchemaComponentsEvent $event) {
             $label = Craft::t('comments', 'Comments');
 
             $event->queries[$label] = [
                 'comments:read' => ['label' => Craft::t('comments', 'View comments')],
+            ];
+
+            $event->mutations[$label] = [
+                'comments:edit' => ['label' => Craft::t('comments', 'Create comments')],
+                'comments:save' => ['label' => Craft::t('comments', 'Save comments')],
+                'comments:delete' => ['label' => Craft::t('comments', 'Delete comments')],
             ];
         });
     }

--- a/src/Comments.php
+++ b/src/Comments.php
@@ -6,7 +6,6 @@ use verbb\comments\elements\Comment;
 use verbb\comments\fields\CommentsField;
 use verbb\comments\fieldlayoutelements\CommentsField as CommentsFieldLayoutElement;
 use verbb\comments\gql\interfaces\CommentInterface;
-use verbb\comments\gql\interfaces\Vote;
 use verbb\comments\gql\queries\CommentQuery;
 use verbb\comments\gql\mutations\Comment as CommentMutations;
 use verbb\comments\helpers\ProjectConfigData;

--- a/src/elements/Comment.php
+++ b/src/elements/Comment.php
@@ -849,8 +849,8 @@ class Comment extends Element
             if ($this->id && !Craft::$app->getRequest()->getIsCpRequest()) {
                 $currentUser = Craft::$app->getUser()->getIdentity();
 
-                if ($currentUser->id !== $this->author->id) {
-                    $this->addError('comment', Craft::t('comments', 'Unable to modify another users comment.'));
+                if (empty($currentUser) || $currentUser->id !== $this->author->id) {
+                    $this->addError('comment', Craft::t('comments', 'Unable to modify another user’s comment.'));
                 }
             }
         }
@@ -901,7 +901,7 @@ class Comment extends Element
                 $currentUser = Craft::$app->getUser()->getIdentity();
 
                 if ($currentUser->id !== $this->author->id) {
-                    $this->addError('comment', Craft::t('comments', 'Unable to modify another users comment.'));
+                    $this->addError('comment', Craft::t('comments', 'Unable to modify another user’s comment.'));
                 }
             }
         }

--- a/src/elements/Comment.php
+++ b/src/elements/Comment.php
@@ -841,7 +841,7 @@ class Comment extends Element
 
             // Is someone sneakily making a comment on a non-allowed element through some black magic POST-ing?
             if (!Comments::$plugin->getComments()->checkPermissions($this->owner)) {
-                $this->addError('comment', Craft::t('comments', 'Comments are disabled for this element.' . $this->ownerId));
+                $this->addError('comment', Craft::t('comments', 'Comments are disabled for this element.'));
             }
 
             // Is this user trying to edit/save/delete a comment that’s not their own?

--- a/src/elements/Comment.php
+++ b/src/elements/Comment.php
@@ -879,7 +879,7 @@ class Comment extends Element
                 $this->addError('comment', Craft::t('comments', 'Must be logged in to comment.'));
             }
 
-            // Additionally, check for user email/name, which is compulsary for guests
+            // Additionally, check for user email/name, which is compulsory for guests
             if ($settings->guestRequireEmailName && !$this->userId) {
                 if (!$this->name) {
                     $this->addError('name', Craft::t('comments', 'Name is required.'));
@@ -895,8 +895,8 @@ class Comment extends Element
                 $this->addError('comment', Craft::t('comments', 'Comments are disabled for this element.'));
             }
 
-            // Is this user trying to edit/save/delete a comment thats not their own?
-            // This is permisable from the CP
+            // Is this user trying to edit/save/delete a comment that’s not their own?
+            // This is permissible from the CP
             if ($this->id && !Craft::$app->getRequest()->getIsCpRequest()) {
                 $currentUser = Craft::$app->getUser()->getIdentity();
 

--- a/src/elements/Comment.php
+++ b/src/elements/Comment.php
@@ -421,7 +421,7 @@ class Comment extends Element
             return $this->_author;
         }
 
-        // If this user is a guest, we make a temprary UserModel, which is particularly
+        // If this user is a guest, we make a temporary UserModel, which is particularly
         // used for email notifications (which require a UserModel instance)
         if ($this->isGuest()) {
             // If this wasn't a registered user...

--- a/src/gql/arguments/mutations/Comment.php
+++ b/src/gql/arguments/mutations/Comment.php
@@ -1,0 +1,59 @@
+<?php
+namespace verbb\comments\gql\arguments\mutations;
+
+use craft\gql\base\ElementMutationArguments;
+use craft\gql\types\DateTime;
+
+use GraphQL\Type\Definition\Type;
+
+class Comment extends ElementMutationArguments
+{
+    /**
+     * @inheritdoc
+     */
+    public static function getArguments(): array
+    {
+        return array_merge(parent::getArguments(), [
+            'ownerId' => [
+                'name' => 'ownerId',
+                'type' => Type::id(),
+                'description' => 'The ID of the element that owns the comment.'
+            ],
+            'siteId' => [
+                'name' => 'siteId',
+                'type' => Type::id(),
+                'description' => 'Site ID the comment belongs to.',
+            ],
+            'newParentId' => [
+                'name' => 'newParentId',
+                'type' => Type::id(),
+                'description' => 'Parent comment ID.',
+            ],
+            'userId' => [
+                'name' => 'userId',
+                'type' => Type::id(),
+                'description' => 'The user ID of the comment’s author.',
+            ],
+            'commentDate' => [
+                'name' => 'commentDate',
+                'type' => DateTime::getType(),
+                'description' => 'The comment\'s post date.'
+            ],
+            'name' => [
+                'name' => 'name',
+                'type' => Type::string(),
+                'description' => 'The full name for the comment\'s author.'
+            ],
+            'email' => [
+                'name' => 'email',
+                'type' => Type::string(),
+                'description' => 'The email for the comment\'s author.'
+            ],
+            'comment' => [
+                'name' => 'comment',
+                'type' => Type::string(),
+                'description' => 'The actual comment text.'
+            ],
+        ]);
+    }
+}

--- a/src/gql/interfaces/CommentInterface.php
+++ b/src/gql/interfaces/CommentInterface.php
@@ -36,9 +36,7 @@ class CommentInterface extends Structure
             'name' => static::getName(),
             'fields' => self::class . '::getFieldDefinitions',
             'description' => 'This is the interface implemented by all comments.',
-            'resolveType' => function(Comment $value) {
-                return $value->getGqlTypeName();
-            },
+            'resolveType' => self::class . '::resolveElementTypeName',
         ]));
 
         CommentGenerator::generateTypes();

--- a/src/gql/interfaces/Flag.php
+++ b/src/gql/interfaces/Flag.php
@@ -1,0 +1,104 @@
+<?php
+namespace verbb\comments\gql\interfaces;
+
+use verbb\comments\helpers\Gql as GqlHelper;
+use verbb\comments\gql\types\Flag as FlagType;
+
+use craft\gql\interfaces\elements\User;
+use craft\gql\TypeManager;
+use craft\gql\GqlEntityRegistry;
+use craft\helpers\Gql;
+
+use GraphQL\Type\Definition\InterfaceType;
+use GraphQL\Type\Definition\Type;
+
+class Flag extends InterfaceType
+{
+    // Public Methods
+    // =========================================================================
+
+    public static function getType($fields = null): Type
+    {
+        if ($type = GqlEntityRegistry::getEntity(self::getName())) {
+            return $type;
+        }
+
+        $type = GqlEntityRegistry::createEntity(self::getName(), new InterfaceType([
+            'name' => static::getName(),
+            'fields' => self::class . '::getFieldDefinitions',
+            'description' => 'This is the interface implemented by all comment votes.',
+            'resolveType' => static function() {
+                // register Vote type that implements this interface
+                return GqlEntityRegistry::getEntity('Flag') ?: GqlEntityRegistry::createEntity('Flag', new FlagType([
+                    'name' => 'Flag',
+                    'fields' => self::getFieldDefinitions(),
+                ]));
+            },
+        ]));
+
+        return $type;
+    }
+
+    public static function getName(): string
+    {
+        return 'FlagInterface';
+    }
+
+    public static function getFieldDefinitions(): array
+    {
+        return TypeManager::prepareFieldDefinitions(array_merge(self::getConditionalFields(), [
+            'id' => [
+                'name' => 'id',
+                'type' => Type::id(),
+                'description' => 'The ID of the flag.'
+            ],
+            'sessionId' => [
+                'name' => 'sessionId',
+                'type' => Type::id(),
+                'description' => 'The session ID from which the vote was submitted.'
+            ],
+            'lastIp' => [
+                'name' => 'lastIp',
+                'type' => Type::string(),
+                'description' => 'The last known IP address of the voter.'
+            ],
+        ]), self::getName());
+    }
+
+    protected static function getConditionalFields(): array
+    {
+        $conditionalFields = [];
+
+        if (Gql::canQueryUsers()) {
+            $conditionalFields = array_merge($conditionalFields, [
+                'userId' => [
+                    'name' => 'userId',
+                    'type' => Type::int(),
+                    'description' => 'The ID of the submitter of this vote.'
+                ],
+                'user' => [
+                    'name' => 'user',
+                    'type' => User::getType(),
+                    'description' => 'The vote\'s submitter.'
+                ],
+            ]);
+        }
+
+        if (GqlHelper::canQueryComments()) {
+            $conditionalFields = array_merge([
+                'commentId' => [
+                    'name' => 'commentId',
+                    'type' => Type::id(),
+                    'description' => 'The ID of the comment the vote is applied to.'
+                ],
+                'comment' => [
+                    'name' => 'comment',
+                    'type' => CommentInterface::getType(),
+                    'description' => 'The comment the vote is applied to.'
+                ],
+            ]);
+        }
+
+        return $conditionalFields;
+    }
+}

--- a/src/gql/interfaces/Vote.php
+++ b/src/gql/interfaces/Vote.php
@@ -1,0 +1,114 @@
+<?php
+namespace verbb\comments\gql\interfaces;
+
+use verbb\comments\helpers\Gql as GqlHelper;
+use verbb\comments\gql\types\Vote as VoteType;
+
+use craft\gql\interfaces\elements\User;
+use craft\gql\TypeManager;
+use craft\gql\GqlEntityRegistry;
+use craft\helpers\Gql;
+
+use GraphQL\Type\Definition\InterfaceType;
+use GraphQL\Type\Definition\Type;
+
+class Vote extends InterfaceType
+{
+    // Public Methods
+    // =========================================================================
+
+    public static function getType($fields = null): Type
+    {
+        if ($type = GqlEntityRegistry::getEntity(self::getName())) {
+            return $type;
+        }
+
+        $type = GqlEntityRegistry::createEntity(self::getName(), new InterfaceType([
+            'name' => static::getName(),
+            'fields' => self::class . '::getFieldDefinitions',
+            'description' => 'This is the interface implemented by all comment votes.',
+            'resolveType' => static function() {
+                // register Vote type that implements this interface
+                return GqlEntityRegistry::getEntity('Vote') ?: GqlEntityRegistry::createEntity('Vote', new VoteType([
+                    'name' => 'Vote',
+                    'fields' => self::getFieldDefinitions(),
+                ]));
+            },
+        ]));
+
+        return $type;
+    }
+
+    public static function getName(): string
+    {
+        return 'VoteInterface';
+    }
+
+    public static function getFieldDefinitions(): array
+    {
+        return TypeManager::prepareFieldDefinitions(array_merge(self::getConditionalFields(), [
+            'id' => [
+                'name' => 'id',
+                'type' => Type::id(),
+                'description' => 'The ID of the vote.'
+            ],
+            'sessionId' => [
+                'name' => 'sessionId',
+                'type' => Type::id(),
+                'description' => 'The session ID from which the vote was submitted.'
+            ],
+            'lastIp' => [
+                'name' => 'lastIp',
+                'type' => Type::string(),
+                'description' => 'The last known IP address of the voter.'
+            ],
+            'upvote' => [
+                'name' => 'upvote',
+                'type' => Type::boolean(),
+                'description' => 'Whether the vote is positive.'
+            ],
+            'downvote' => [
+                'name' => 'downvote',
+                'type' => Type::boolean(),
+                'description' => 'Whether the vote is negative.'
+            ],
+        ]), self::getName());
+    }
+
+    protected static function getConditionalFields(): array
+    {
+        $conditionalFields = [];
+
+        if (Gql::canQueryUsers()) {
+            $conditionalFields = array_merge($conditionalFields, [
+                'userId' => [
+                    'name' => 'userId',
+                    'type' => Type::int(),
+                    'description' => 'The ID of the submitter of this vote.'
+                ],
+                'user' => [
+                    'name' => 'user',
+                    'type' => User::getType(),
+                    'description' => 'The vote\'s submitter.'
+                ],
+            ]);
+        }
+
+        if (GqlHelper::canQueryComments()) {
+            $conditionalFields = array_merge([
+                'commentId' => [
+                    'name' => 'commentId',
+                    'type' => Type::id(),
+                    'description' => 'The ID of the comment the vote is applied to.'
+                ],
+                'comment' => [
+                    'name' => 'comment',
+                    'type' => CommentInterface::getType(),
+                    'description' => 'The comment the vote is applied to.'
+                ],
+            ]);
+        }
+
+        return $conditionalFields;
+    }
+}

--- a/src/gql/mutations/Comment.php
+++ b/src/gql/mutations/Comment.php
@@ -1,12 +1,14 @@
 <?php
 namespace verbb\comments\gql\mutations;
 
+use verbb\comments\Comments;
 use verbb\comments\gql\arguments\mutations\Comment as CommentMutationArguments;
 use verbb\comments\gql\interfaces\CommentInterface;
 use verbb\comments\gql\interfaces\Flag;
 use verbb\comments\gql\interfaces\Vote;
 use verbb\comments\gql\resolvers\mutations\Comment as CommentMutationResolver;
 use verbb\comments\helpers\Gql as GqlHelper;
+use verbb\comments\models\Settings;
 
 use craft\gql\base\Mutation;
 use Craft;
@@ -24,6 +26,8 @@ class Comment extends Mutation
             return [];
         }
 
+        /** @var Settings $settings */
+        $settings = Comments::$plugin->getSettings();
         $mutationList = [];
         $scope = 'comments';
         $resolver = Craft::createObject(CommentMutationResolver::class);
@@ -47,18 +51,20 @@ class Comment extends Mutation
                 'type' => CommentInterface::getType(),
             ];
 
-            $mutationList['voteComment'] = [
-                'name' => 'voteComment',
-                'args' => [
-                    'id' => Type::nonNull(Type::id()),
-                    'siteId' => Type::id(),
-                    'upvote' => Type::boolean(),
-                    'downvote' => Type::boolean(),
-                ],
-                'resolve' => [$resolver, 'voteComment'],
-                'description' => 'Vote on a comment.',
-                'type' => Vote::getType(),
-            ];
+            if ($settings->allowVoting) {
+                $mutationList['voteComment'] = [
+                    'name' => 'voteComment',
+                    'args' => [
+                        'id' => Type::nonNull(Type::id()),
+                        'siteId' => Type::id(),
+                        'upvote' => Type::boolean(),
+                        'downvote' => Type::boolean(),
+                    ],
+                    'resolve' => [$resolver, 'voteComment'],
+                    'description' => 'Vote on a comment.',
+                    'type' => Vote::getType(),
+                ];
+            }
 
             $mutationList['flagComment'] = [
                 'name' => 'flagComment',

--- a/src/gql/mutations/Comment.php
+++ b/src/gql/mutations/Comment.php
@@ -66,16 +66,18 @@ class Comment extends Mutation
                 ];
             }
 
-            $mutationList['flagComment'] = [
-                'name' => 'flagComment',
-                'args' => [
-                    'id' => Type::nonNull(Type::id()),
-                    'siteId' => Type::id(),
-                ],
-                'resolve' => [$resolver, 'flagComment'],
-                'description' => 'Flag a comment.',
-                'type' => Flag::getType(),
-            ];
+            if ($settings->allowFlagging) {
+                $mutationList['flagComment'] = [
+                    'name' => 'flagComment',
+                    'args' => [
+                        'id' => Type::nonNull(Type::id()),
+                        'siteId' => Type::id(),
+                    ],
+                    'resolve' => [$resolver, 'flagComment'],
+                    'description' => 'Flag a comment.',
+                    'type' => Flag::getType(),
+                ];
+            }
 
             $mutationList['subscribeComment'] = [
                 'name' => 'subscribeComment',

--- a/src/gql/mutations/Comment.php
+++ b/src/gql/mutations/Comment.php
@@ -1,0 +1,88 @@
+<?php
+namespace verbb\comments\gql\mutations;
+
+use verbb\comments\gql\arguments\mutations\Comment as CommentMutationArguments;
+use verbb\comments\gql\interfaces\CommentInterface;
+use verbb\comments\gql\resolvers\mutations\Comment as CommentMutationResolver;
+use verbb\comments\helpers\Gql as GqlHelper;
+
+use craft\gql\base\Mutation;
+use Craft;
+
+use GraphQL\Type\Definition\Type;
+
+class Comment extends Mutation
+{
+    // Public Methods
+    // =========================================================================
+
+    public static function getMutations(): array
+    {
+        if (!GqlHelper::canMutateComments()) {
+            return [];
+        }
+
+        $mutationList = [];
+        $scope = 'comments';
+        $resolver = Craft::createObject(CommentMutationResolver::class);
+
+        if (GqlHelper::canSchema($scope, 'edit')) {
+            $mutationList['createComment'] = [
+                'name' => 'createComment',
+                'args' => CommentMutationArguments::getArguments(),
+                'resolve' => [$resolver, 'saveComment'],
+                'description' => 'Create a comment.',
+                'type' => CommentInterface::getType(),
+            ];
+        }
+
+        if (GqlHelper::canSchema($scope, 'save')) {
+            $mutationList['saveComment'] = [
+                'name' => 'saveComment',
+                'args' => CommentMutationArguments::getArguments(),
+                'resolve' => [$resolver, 'saveComment'],
+                'description' => 'Save a comment.',
+                'type' => CommentInterface::getType(),
+            ];
+
+            $mutationList['voteComment'] = [
+                'name' => 'voteComment',
+                'args' => [
+                    'id' => Type::nonNull(Type::int()),
+                    'siteId' => Type::int(),
+                    'upvote' => Type::boolean(),
+                    'downvote' => Type::boolean(),
+                ],
+                'resolve' => [$resolver, 'voteComment'],
+                'description' => 'Vote on a comment.',
+                'type' => CommentInterface::getType(),
+            ];
+
+            $mutationList['flagComment'] = [
+                'name' => 'flagComment',
+                'args' => [
+                    'id' => Type::nonNull(Type::int()),
+                    'siteId' => Type::int(),
+                ],
+                'resolve' => [$resolver, 'flagComment'],
+                'description' => 'Flag a comment.',
+                'type' => CommentInterface::getType(),
+            ];
+        }
+
+        if (GqlHelper::canSchema($scope, 'delete')) {
+            $mutationList['deleteComment'] = [
+                'name' => 'deleteComment',
+                'args' => [
+                    'id' => Type::nonNull(Type::int()),
+                    'siteId' => Type::int(),
+                ],
+                'resolve' => [$resolver, 'deleteComment'],
+                'description' => 'Delete a comment.',
+                'type' => Type::boolean(),
+            ];
+        }
+
+        return $mutationList;
+    }
+}

--- a/src/gql/mutations/Comment.php
+++ b/src/gql/mutations/Comment.php
@@ -83,9 +83,9 @@ class Comment extends Mutation
                 $mutationList['subscribeComment'] = [
                     'name' => 'subscribeComment',
                     'args' => [
-                        'id' => Type::id(),
-                        'siteId' => Type::id(),
                         'ownerId' => Type::nonNull(Type::id()),
+                        'siteId' => Type::id(),
+                        'commentId' => Type::id(),
                     ],
                     'resolve' => [$resolver, 'subscribeComment'],
                     'description' => 'Toggle comment thread subscription.',

--- a/src/gql/mutations/Comment.php
+++ b/src/gql/mutations/Comment.php
@@ -3,6 +3,8 @@ namespace verbb\comments\gql\mutations;
 
 use verbb\comments\gql\arguments\mutations\Comment as CommentMutationArguments;
 use verbb\comments\gql\interfaces\CommentInterface;
+use verbb\comments\gql\interfaces\Flag;
+use verbb\comments\gql\interfaces\Vote;
 use verbb\comments\gql\resolvers\mutations\Comment as CommentMutationResolver;
 use verbb\comments\helpers\Gql as GqlHelper;
 
@@ -48,25 +50,37 @@ class Comment extends Mutation
             $mutationList['voteComment'] = [
                 'name' => 'voteComment',
                 'args' => [
-                    'id' => Type::nonNull(Type::int()),
-                    'siteId' => Type::int(),
+                    'id' => Type::nonNull(Type::id()),
+                    'siteId' => Type::id(),
                     'upvote' => Type::boolean(),
                     'downvote' => Type::boolean(),
                 ],
                 'resolve' => [$resolver, 'voteComment'],
                 'description' => 'Vote on a comment.',
-                'type' => CommentInterface::getType(),
+                'type' => Vote::getType(),
             ];
 
             $mutationList['flagComment'] = [
                 'name' => 'flagComment',
                 'args' => [
-                    'id' => Type::nonNull(Type::int()),
-                    'siteId' => Type::int(),
+                    'id' => Type::nonNull(Type::id()),
+                    'siteId' => Type::id(),
                 ],
                 'resolve' => [$resolver, 'flagComment'],
                 'description' => 'Flag a comment.',
-                'type' => CommentInterface::getType(),
+                'type' => Flag::getType(),
+            ];
+
+            $mutationList['subscribeComment'] = [
+                'name' => 'subscribeComment',
+                'args' => [
+                    'id' => Type::id(),
+                    'siteId' => Type::id(),
+                    'ownerId' => Type::nonNull(Type::id()),
+                ],
+                'resolve' => [$resolver, 'subscribeComment'],
+                'description' => 'Toggle comment thread subscription.',
+                'type' => Type::string(),
             ];
         }
 
@@ -74,8 +88,8 @@ class Comment extends Mutation
             $mutationList['deleteComment'] = [
                 'name' => 'deleteComment',
                 'args' => [
-                    'id' => Type::nonNull(Type::int()),
-                    'siteId' => Type::int(),
+                    'id' => Type::nonNull(Type::id()),
+                    'siteId' => Type::id(),
                 ],
                 'resolve' => [$resolver, 'deleteComment'],
                 'description' => 'Delete a comment.',

--- a/src/gql/mutations/Comment.php
+++ b/src/gql/mutations/Comment.php
@@ -79,17 +79,19 @@ class Comment extends Mutation
                 ];
             }
 
-            $mutationList['subscribeComment'] = [
-                'name' => 'subscribeComment',
-                'args' => [
-                    'id' => Type::id(),
-                    'siteId' => Type::id(),
-                    'ownerId' => Type::nonNull(Type::id()),
-                ],
-                'resolve' => [$resolver, 'subscribeComment'],
-                'description' => 'Toggle comment thread subscription.',
-                'type' => Type::string(),
-            ];
+            if ($settings->notificationSubscribeEnabled) {
+                $mutationList['subscribeComment'] = [
+                    'name' => 'subscribeComment',
+                    'args' => [
+                        'id' => Type::id(),
+                        'siteId' => Type::id(),
+                        'ownerId' => Type::nonNull(Type::id()),
+                    ],
+                    'resolve' => [$resolver, 'subscribeComment'],
+                    'description' => 'Toggle comment thread subscription.',
+                    'type' => Type::string(),
+                ];
+            }
         }
 
         if (GqlHelper::canSchema($scope, 'delete')) {

--- a/src/gql/queries/CommentQuery.php
+++ b/src/gql/queries/CommentQuery.php
@@ -28,6 +28,12 @@ class CommentQuery extends Query
                 'resolve' => CommentResolver::class . '::resolve',
                 'description' => 'This query is used to query for comments.',
             ],
+            'comment' => [
+                'type' => CommentInterface::getType(),
+                'args' => CommentArguments::getArguments(),
+                'resolve' => CommentResolver::class . '::resolveOne',
+                'description' => 'This query is used to query for a comment.',
+            ],
         ];
     }
 }

--- a/src/gql/resolvers/mutations/Comment.php
+++ b/src/gql/resolvers/mutations/Comment.php
@@ -170,6 +170,10 @@ class Comment extends ElementMutationResolver
         $commentId = $arguments['id'];
         $userId = $currentUser->id ?? null;
 
+        if (!$settings->allowFlagging) {
+            throw new UserError(Craft::t('comments', 'Flagging is not allowed.'));
+        }
+
         if (empty($currentUser) && !$settings->allowGuestFlagging) {
             throw new UserError(Craft::t('comments', 'Must be logged in to flag comments.'));
         }

--- a/src/gql/resolvers/mutations/Comment.php
+++ b/src/gql/resolvers/mutations/Comment.php
@@ -70,6 +70,10 @@ class Comment extends ElementMutationResolver
         $comment = $this->getCommentElement($arguments);
         $comment = $this->populateElementWithData($comment, $arguments);
 
+        if (!$comment->userId) {
+            $comment->userId = $currentUser->id ?? null;
+        }
+
         // Set any new comment to be pending if requireModeration is true
         if ($settings->requireModeration) {
             $comment->status = CommentElement::STATUS_PENDING;

--- a/src/gql/resolvers/mutations/Comment.php
+++ b/src/gql/resolvers/mutations/Comment.php
@@ -249,9 +249,14 @@ class Comment extends ElementMutationResolver
         $commentId = $arguments['id'];
         $elementService = Craft::$app->getElements();
         $comment = $elementService->getElementById($commentId);
+        $currentUser = Craft::$app->getUser()->getIdentity();
 
         if (!$comment) {
             return true;
+        }
+
+        if ($comment->userId !== $currentUser->id) {
+            throw new UserError(Craft::t('comments', 'You may only delete your own comments.'));
         }
 
         $this->requireSchemaAction('comments', 'delete');

--- a/src/gql/resolvers/mutations/Comment.php
+++ b/src/gql/resolvers/mutations/Comment.php
@@ -70,7 +70,12 @@ class Comment extends ElementMutationResolver
         $comment = $this->getCommentElement($arguments);
         $comment = $this->populateElementWithData($comment, $arguments);
 
-        if (!$comment->userId) {
+        // If we’re logged in and not editing our own comment, make sure a new one’s allowed
+        if (! empty($currentUser) && !$comment->userId && !$canIdentify) {
+            if (! $settings->canComment($comment)) {
+                throw new UserError(Craft::t('comments', 'Comment not allowed.'));
+            }
+
             $comment->userId = $currentUser->id ?? null;
         }
 

--- a/src/gql/resolvers/mutations/Comment.php
+++ b/src/gql/resolvers/mutations/Comment.php
@@ -19,6 +19,11 @@ use GraphQL\Error\Error;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Error\UserError;
 
+/**
+ * Implements custom mutation methods take GraphQL mutations and make stuff happen.
+ *
+ * @package verbb\comments\gql\resolvers\mutations
+ */
 class Comment extends ElementMutationResolver
 {
     use StructureMutationTrait;
@@ -27,7 +32,7 @@ class Comment extends ElementMutationResolver
     protected $immutableAttributes = ['id', 'uid', 'userId'];
 
     /**
-     * Handles GraphQL query arguments to either create or update a comment.
+     * Handles GraphQL mutation arguments to either create or update a comment.
      *
      * @param             $source
      * @param array       $arguments    GraphQL query arguments in key-value pairs
@@ -79,7 +84,7 @@ class Comment extends ElementMutationResolver
     }
 
     /**
-     * Handles GraphQL query arguments to record a comment upvote or downvote.
+     * Handles GraphQL mutation arguments to record a comment upvote or downvote.
      *
      * @param             $source
      * @param array       $arguments    GraphQL query arguments in key-value pairs
@@ -138,7 +143,7 @@ class Comment extends ElementMutationResolver
     }
 
     /**
-     * Handles GraphQL query arguments to flag a comment.
+     * Handles GraphQL mutation arguments to flag a comment.
      *
      * @param             $source
      * @param array       $arguments    GraphQL query arguments in key-value pairs
@@ -174,7 +179,16 @@ class Comment extends ElementMutationResolver
         return $flag;
     }
 
-    public function subscribeComment($source, array $arguments, $context, ResolveInfo $resolveInfo)
+    /**
+     * Handles GraphQL mutation arguments to toggle comment subscription.
+     *
+     * @param             $source
+     * @param array       $arguments    GraphQL query arguments in key-value pairs
+     * @param             $context
+     * @param ResolveInfo $resolveInfo
+     * @return string
+     */
+    public function subscribeComment($source, array $arguments, $context, ResolveInfo $resolveInfo): string
     {
         $currentUser = Craft::$app->getUser()->getIdentity();
         $commentId = $arguments['id'] ?? null;
@@ -207,8 +221,10 @@ class Comment extends ElementMutationResolver
     }
 
     /**
+     * Handles GraphQL mutation arguments to delete a comment.
+
      * @param             $source
-     * @param array       $arguments
+     * @param array       $arguments    GraphQL query arguments in key-value pairs
      * @param             $context
      * @param ResolveInfo $resolveInfo
      * @return bool
@@ -238,7 +254,7 @@ class Comment extends ElementMutationResolver
      * @throws Error
      * @throws SiteNotFoundException
      */
-    public function getCommentElement($arguments)
+    protected function getCommentElement(array $arguments): CommentElement
     {
         $canIdentify = !empty($arguments['id']) || !empty($arguments['uid']);
         $this->requireSchemaAction('comments', $canIdentify ? 'save' : 'edit');

--- a/src/gql/resolvers/mutations/Comment.php
+++ b/src/gql/resolvers/mutations/Comment.php
@@ -61,7 +61,10 @@ class Comment extends ElementMutationResolver
         $currentUser = Craft::$app->getUser()->getIdentity();
 
         if (empty($currentUser) && !$settings->allowGuest) {
-            throw new UserError(Craft::t('comments', 'Must be logged in to comment.'));
+            $message = ! empty($settings->guestNotice) ?
+                $settings->guestNotice :
+                Craft::t('comments', 'Must be logged in to comment.');
+            throw new UserError($message);
         }
 
         $comment = $this->getCommentElement($arguments);

--- a/src/gql/resolvers/mutations/Comment.php
+++ b/src/gql/resolvers/mutations/Comment.php
@@ -106,6 +106,10 @@ class Comment extends ElementMutationResolver
         $settings = Comments::$plugin->getSettings();
         $currentUser = Craft::$app->getUser()->getIdentity();
 
+        if (!$settings->allowVoting) {
+            throw new UserError(Craft::t('comments', 'Voting is not allowed.'));
+        }
+
         if (empty($currentUser) && !$settings->allowGuestVoting) {
             throw new UserError(Craft::t('comments', 'Must be logged in to vote.'));
         }

--- a/src/gql/resolvers/mutations/Comment.php
+++ b/src/gql/resolvers/mutations/Comment.php
@@ -1,0 +1,165 @@
+<?php
+namespace verbb\comments\gql\resolvers\mutations;
+
+use craft\base\ElementInterface;
+use verbb\comments\Comments;
+use verbb\comments\elements\Comment as CommentElement;
+use verbb\comments\elements\db\CommentQuery;
+
+use craft\errors\GqlException;
+use craft\errors\SiteNotFoundException;
+use craft\gql\base\ElementMutationResolver;
+use craft\gql\base\StructureMutationTrait;
+use Craft;
+
+use GraphQL\Error\Error;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Error\UserError;
+
+class Comment extends ElementMutationResolver
+{
+    use StructureMutationTrait;
+
+    /* @inheritdoc */
+    protected $immutableAttributes = ['id', 'uid', 'userId'];
+
+    /**
+     * @param             $source
+     * @param array       $arguments
+     * @param             $context
+     * @param ResolveInfo $resolveInfo
+     * @return ElementInterface|null
+     * @throws GqlException|Error
+     */
+    public function saveComment($source, array $arguments, $context, ResolveInfo $resolveInfo)
+    {
+        $canIdentify = !empty($arguments['id']) || !empty($arguments['uid']);
+        $elementService = Craft::$app->getElements();
+        $settings = Comments::$plugin->getSettings();
+
+        if ($canIdentify) {
+            $this->requireSchemaAction('comments', 'save');
+        } else {
+            $this->requireSchemaAction('comments', 'edit');
+        }
+
+        $comment = $this->getCommentElement($arguments);
+        $comment = $this->populateElementWithData($comment, $arguments);
+
+        // Set any new comment to be pending if requireModeration is true
+        if ($settings->requireModeration) {
+            $comment->status = CommentElement::STATUS_PENDING;
+        } else {
+            $comment->status = CommentElement::STATUS_APPROVED;
+        }
+
+        if (isset($arguments['newParentId'])) {
+            $comment->newParentId = $arguments['newParentId'];
+        }
+
+        $comment->setScenario(CommentElement::SCENARIO_LIVE);
+        $comment = $this->saveElement($comment);
+
+        if ($comment->hasErrors()) {
+            $validationErrors = [];
+
+            foreach ($comment->getFirstErrors() as $attribute => $errorMessage) {
+                $validationErrors[] = $errorMessage;
+            }
+
+            throw new UserError(implode("\n", $validationErrors));
+        }
+
+        return $elementService->getElementById($comment->id, CommentElement::class);
+    }
+
+    public function voteComment($source, array $arguments, $context, ResolveInfo $resolveInfo)
+    {
+        // TODO: follow CommentsController::actionVote()
+    }
+
+    public function flagComment($source, array $arguments, $context, ResolveInfo $resolveInfo)
+    {
+        // TODO: follow CommentsController::actionFlag()
+    }
+
+    /**
+     * @param             $source
+     * @param array       $arguments
+     * @param             $context
+     * @param ResolveInfo $resolveInfo
+     * @return bool
+     * @throws \Throwable
+     */
+    public function deleteComment($source, array $arguments, $context, ResolveInfo $resolveInfo): bool
+    {
+        $commentId = $arguments['id'];
+        $elementService = Craft::$app->getElements();
+        $comment = $elementService->getElementById($commentId);
+
+        if (!$comment) {
+            return true;
+        }
+
+        $this->requireSchemaAction('comments', 'delete');
+        $elementService->deleteElementById($commentId);
+
+        return true;
+    }
+
+    /**
+     * Returns a new or existing Comment element based on the provided query parameters.
+     *
+     * @param array $arguments GraphQL query arguments in key-value pairs
+     * @return CommentElement
+     * @throws Error
+     * @throws SiteNotFoundException
+     */
+    public function getCommentElement($arguments)
+    {
+        $canIdentify = !empty($arguments['id']) || !empty($arguments['uid']);
+        $this->requireSchemaAction('comments', $canIdentify ? 'save' : 'edit');
+        $elementService = Craft::$app->getElements();
+
+        if ($canIdentify) {
+            $siteId = $arguments['siteId'] ?? Craft::$app->getSites()->getPrimarySite()->id;
+            $commentQuery = $elementService->createElementQuery(CommentElement::class)
+                ->anyStatus()
+                ->siteId($siteId);
+            $commentQuery = $this->identifyComment($commentQuery, $arguments);
+            $comment = $commentQuery->one();
+
+            if (!$comment) {
+                throw new Error('No such comment exists');
+            }
+        } else {
+            $comment = $elementService->createElement(CommentElement::class);
+        }
+
+        return $comment;
+    }
+
+    /**
+     * Attempts to use GraphQL query arguments to set the appropriate ID on a Craft element query.
+     *
+     * If the arguments don’t contain a UID or ID, sets ID to -1 so the element query doesn’t return
+     * any results.
+     *
+     * @param CommentQuery $commentQuery
+     * @param array        $arguments     GraphQL query arguments in key-value pairs
+     * @return CommentQuery
+     */
+    protected function identifyComment(CommentQuery $commentQuery, array $arguments): CommentQuery
+    {
+        if (!empty($arguments['uid'])) {
+            $commentQuery->uid($arguments['uid']);
+        } else if (!empty($arguments['id'])) {
+            $commentQuery->id($arguments['id']);
+        } else {
+            // Unable to identify, make sure nothing is returned.
+            $commentQuery->id(-1);
+        }
+
+        return $commentQuery;
+    }
+}

--- a/src/gql/types/Flag.php
+++ b/src/gql/types/Flag.php
@@ -1,0 +1,26 @@
+<?php
+namespace verbb\comments\gql\types;
+
+use GraphQL\Type\Definition\ResolveInfo;
+use verbb\comments\gql\interfaces\Flag as FlagInterface;
+use craft\gql\base\ObjectType;
+
+class Flag extends ObjectType
+{
+    public function __construct(array $config)
+    {
+        $config['interfaces'] = [
+            FlagInterface::getType(),
+        ];
+
+        parent::__construct($config);
+    }
+
+    protected function resolve($source, $arguments, $context, ResolveInfo $resolveInfo)
+    {
+        /** @var \verbb\comments\models\Flag $source */
+        $fieldName = $resolveInfo->fieldName;
+
+        return parent::resolve($source, $arguments, $context, $resolveInfo);
+    }
+}

--- a/src/gql/types/Vote.php
+++ b/src/gql/types/Vote.php
@@ -1,0 +1,26 @@
+<?php
+namespace verbb\comments\gql\types;
+
+use GraphQL\Type\Definition\ResolveInfo;
+use verbb\comments\gql\interfaces\Vote as VoteInterface;
+use craft\gql\base\ObjectType;
+
+class Vote extends ObjectType
+{
+    public function __construct(array $config)
+    {
+        $config['interfaces'] = [
+            VoteInterface::getType(),
+        ];
+
+        parent::__construct($config);
+    }
+
+    protected function resolve($source, $arguments, $context, ResolveInfo $resolveInfo)
+    {
+        /** @var \verbb\comments\models\Vote $source */
+        $fieldName = $resolveInfo->fieldName;
+
+        return parent::resolve($source, $arguments, $context, $resolveInfo);
+    }
+}

--- a/src/helpers/Gql.php
+++ b/src/helpers/Gql.php
@@ -2,15 +2,23 @@
 namespace verbb\comments\helpers;
 
 use craft\helpers\Gql as GqlHelper;
+use craft\models\GqlSchema;
 
 class Gql extends GqlHelper
 {
     // Public Methods
     // =========================================================================
 
-    public static function canQueryComments(): bool
+    public static function canQueryComments($schema = null): bool
     {
-        $allowedEntities = self::extractAllowedEntitiesFromSchema();
+        $allowedEntities = self::extractAllowedEntitiesFromSchema('read', $schema);
+
+        return isset($allowedEntities['comments']);
+    }
+
+    public static function canMutateComments($schema = null): bool
+    {
+        $allowedEntities = self::extractAllowedEntitiesFromSchema('edit', $schema);
 
         return isset($allowedEntities['comments']);
     }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -93,8 +93,20 @@ class Settings extends Model
     public $showCustomFieldInstructions = false;
 
     // Deprecated
+
+    /**
+     * @deprecated in 1.4.0. Use Settings::$allowGuest instead.
+     */
     public $allowAnonymous;
+
+    /**
+     * @deprecated in 1.4.0. Use Settings::$allowGuestVoting instead.
+     */
     public $allowAnonymousVoting;
+
+    /**
+     * @deprecated in 1.4.0. Use Settings::$allowGuestFlagging instead.
+     */
     public $allowAnonymousFlagging;
 
     private $_placeholderAvatar = null;

--- a/src/templates/settings/_panes/security.html
+++ b/src/templates/settings/_panes/security.html
@@ -33,7 +33,7 @@
 
 {{ forms.lightswitchField({
     label: 'Enable Spam Checks' | t('comments'),
-    instructions: 'Whether to enable spam checks for comments.' | t('comments'),
+    instructions: 'Whether to enable spam checks for form-based comments.' | t('comments'),
     name: 'enableSpamChecks',
     on: settings.enableSpamChecks,
     warning: macros.configWarning('enableSpamChecks', 'comments'),

--- a/src/translations/nl/comments.php
+++ b/src/translations/nl/comments.php
@@ -46,7 +46,7 @@ return [
 	'Must be logged in to comment.' => 'Inloggen verplicht.',
 	'Name is required.' => 'Naam is vereist.',
 	'Email is required.' => 'Email is vereist.',
-	'Unable to modify another users comment.' => 'Je kan andermans reactie niet bewerken.',
+	'Unable to modify another user’s comment.' => 'Je kan andermans reactie niet bewerken.',
 	'Comment must not be blank.' => 'Reactie mag niet leeg zijn.',
 	'Comments are disabled for this element.' => 'Reacties zijn uitgeschakeld.'
 ];


### PR DESCRIPTION
## Description

This PR-in-progress adds mutation support to approximate front-end controller actions via the GraphQL API.

There’s some architectural gray area—at least for me—since GraphQL includes a concept of customizable schemas and tokens, where a Craft User session may or may not be relevant or available depending on how the plugin is used. It seems like it’s best to support plugin settings wherever possible rather than duplicating them, keeping the schema components simple.

Comments are saved using `SCENARIO_LIVE`, mimicking Craft’s own elements+GraphQL. It seems like this scenario was previously unused and safe to set up exclusively for use via GraphQL.

This randomly adds a `comment` query for getting a single comment in addition to the existing `comments` one—mostly for fun and to follow the pattern used by first-party element types.

### Features

GraphQL features to be supported and tested.

> ✓: supported and tested

- [x] comment creation via `saveComment`
    - [x] mutation as guest 
    - [x] + nesting/target selection 
    - [x] mutation as user
    - [x] custom fields
- [x] comment editing via `saveComment` with ID
    - [x] edit as guest
    - [x] edit own comments (user)
    - [x] cannot edit others’ comments (user)
    - [x] custom fields
- [x] comment upvote/downvote via `voteComment`
    - [x] vote up or down as guest
    - [x] vote up or down as user 
- [x] comment flagging via `flagComment`
    - [x] flag as guest
    - [x] flag as user
- [x] comment subscribe/unsubscribe via `subscribeComment`
    - [x] cannot toggle as guest
    - [x] can toggle as user
- [x] comment deletion via `deleteComment`
    - [x] cannot delete any comments as guest 
    - [x] delete own comments (user) 

### Validation

Exhaustive list of settings to check against. (Some may already be supported and just need testing.)

> ✓: supported and tested

- [x] honors *Allow Guest Comments* setting
     - [x] honors *Guest Notice* setting with custom “must log in” message 
- [x] honors *Require Email and Name* for Guests setting
- [x] honors *Maximum Reply Depth* setting
- [x] honors *Maximum Comments per-user* setting
- [x] honors *Allow Subscriber Notifications* setting
- [x] honors *Allow Per-Comment Subscriber Notifications* setting
- [x] honors *Enable Voting* setting
- [x] honors *Enable Guest Voting* setting
- [x] honors *Enable Flagging* setting
- [x] honors *Enable Guest Flagging* setting
- [x] honors *Maximum Comment Length* setting
- [x] honors *Minimum Time Between Comments* setting
- [x] honors individual per-element-type permissions (**Settings** → **Permissions**)