### PR TITLE
Adding a way to get the reason for commenting being unavailable (addresses #244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.12 - 2021-12-02
+
+### Added
+- Added a new settings function, `commentingAvailable()`, which will provide more detailed information on why commenting is not available on an element. (It can be accessed via Twig, too, if you are using custom comment templates!)
+
 ## 1.8.11 - 2021-10-30
 
 ### Changed

--- a/src/enums/CommentStatus.php
+++ b/src/enums/CommentStatus.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ */
+
+namespace verbb\comments\enums;
+
+/**
+ * The CommentStatus class is an abstract class that defines all of the possible states for commenting on an element.
+ * (There is one 'available' case and several different 'unavailable' cases.)
+ * 
+ * This class is a poor man's version of an enum copied from P&T's basic pattern in Craft CMS, 
+ * since PHP does not have support for native enumerations.
+ */
+abstract class CommentStatus
+{
+    const Allowed           = array('permission' => true,  'reason' => 'Allowed');
+    const Expired           = array('permission' => false, 'reason' => 'Expired');
+    const ManuallyClosed    = array('permission' => false, 'reason' => 'ManuallyClosed');
+    const Unpermitted       = array('permission' => false, 'reason' => 'Unpermitted');
+    const NoGuests          = array('permission' => false, 'reason' => 'NoGuests');
+    const TooManyComments   = array('permission' => false, 'reason' => 'TooManyComments');
+    const UserBanned        = array('permission' => false, 'reason' => 'UserBanned');
+}

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -3,6 +3,7 @@ namespace verbb\comments\models;
 
 use verbb\comments\Comments;
 use verbb\comments\elements\Comment;
+use verbb\comments\enums\CommentStatus;
 
 use Craft;
 use craft\base\Model;
@@ -132,24 +133,37 @@ class Settings extends Model
         return null;
     }
 
+    /* this needs to return a boolean */
     public function canComment($element)
     {
-        $isClosed = Comments::$plugin->getComments()->checkClosed($element);
+        $isAllowed = $this->commentingAvailable($element);
+        return $isAllowed['permission'];
+    }
+
+    public function commentingAvailable($element)
+    {
+        $isClosed = Comments::$plugin->getComments()->checkManuallyClosed($element);
 
         if ($isClosed) {
-            return false;
+            return CommentStatus::ManuallyClosed;
+        }
+
+        $isExpired = Comments::$plugin->getComments()->checkExpired($element);
+
+        if ($isExpired) {
+            return CommentStatus::Expired;
         }
 
         $hasPermission = Comments::$plugin->getComments()->checkPermissions($element);
 
         if (!$hasPermission) {
-            return false;
+            return CommentStatus::Unpermitted;
         }
 
         $currentUser = Comments::$plugin->getService()->getUser();
 
         if (!$currentUser && !$this->allowGuest) {
-            return false;
+            return CommentStatus::NoGuests;
         }
 
         if ($this->maxUserComments && $currentUser) {
@@ -157,11 +171,11 @@ class Settings extends Model
             $count = Comment::find()->ownerId($element->id)->userId($currentUser->id)->count();
 
             if ($count >= $this->maxUserComments) {
-                return false;
+                return CommentStatus::TooManyComments;
             }
         }
 
-        return true;
+        return CommentStatus::Allowed;
     }
 
     public function getStructureId()
@@ -175,7 +189,7 @@ class Settings extends Model
 
     public function getEnabledNotificationAdmins()
     {
-        $notificationAdmins = $this->notificationAdmins ?: [];
+        $notificationAdmins = $this->notificationAdmins ?? [];
 
         return ArrayHelper::where($notificationAdmins, 'enabled');
     }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -189,7 +189,7 @@ class Settings extends Model
 
     public function getEnabledNotificationAdmins()
     {
-        $notificationAdmins = $this->notificationAdmins ?? [];
+        $notificationAdmins = $this->notificationAdmins ?: [];
 
         return ArrayHelper::where($notificationAdmins, 'enabled');
     }

--- a/src/services/CommentsService.php
+++ b/src/services/CommentsService.php
@@ -229,14 +229,19 @@ class CommentsService extends Component
         return true;
     }
 
-    public function checkClosed($element)
+    public function checkManuallyClosed($element)
     {
-        $settings = Comments::$plugin->getSettings();
-
-        // Has this comment been manually closed? Takes precedence
+        // Has this comment been manually closed?
         if (!$this->_checkOwnerFieldEnabled($element)) {
             return true;
         }
+
+        return false;
+    }
+
+    public function checkExpired($element)
+    {
+        $settings = Comments::$plugin->getSettings();
 
         // Has this element's publish date exceeded the set auto-close limit? Does it even have a auto-close limit?
         if ($settings->autoCloseDays) {


### PR DESCRIPTION
This addresses my FR #244, adding a way to obtain more detailed information about why commenting is unavailable on an entry. It changes very little about the underlying behavior of the checks (the only behavior _change_ is to add a split between checking for manually-closed vs expired elements.)