### PR TITLE
URGENT: Fixes error with new version of Craft

### DIFF
--- a/src/fieldlayoutelements/CommentsField.php
+++ b/src/fieldlayoutelements/CommentsField.php
@@ -62,7 +62,7 @@ class CommentsField extends BaseField
         return '__blank__';
     }
 
-    public function instructions()
+    public function instructions(?craft\base\ElementInterface $element = NULL, bool $static = false): ?string
     {
         if ($this->instructions !== null && $this->instructions !== '' && $this->instructions !== '__blank__') {
             return Html::encode(Craft::t('comments', $this->instructions));


### PR DESCRIPTION
Craft 3.7.24 broke the Comments plugin in a super bad way because of a function signature error; this fixes that, @engram-design 
