### PR TITLE
Add support for Votes to Feed Me integration

### DIFF
--- a/src/integrations/CommentFeedMeElement.php
+++ b/src/integrations/CommentFeedMeElement.php
@@ -3,6 +3,7 @@ namespace verbb\comments\integrations;
 
 use verbb\comments\Comments;
 use verbb\comments\elements\Comment as CommentElement;
+use verbb\comments\records\Vote as VoteRecord;
 
 use Craft;
 use craft\base\ElementInterface;
@@ -62,6 +63,7 @@ class CommentFeedMeElement extends Element
         Event::on(Process::class, Process::EVENT_STEP_AFTER_ELEMENT_SAVE, function(FeedProcessEvent $event): void {
             if ($event->feed['elementType'] === CommentElement::class) {
                 $this->_processNestedComments($event);
+                $this->_processVotes($event);
             }
         });
     }
@@ -220,6 +222,110 @@ class CommentFeedMeElement extends Element
         return null;
     }
 
+    protected function _processVotes($event): void
+    {
+        // Save the imported comment as the parent, we'll need it in a sec
+        $parentId = $event->element->id;
+
+        // Check if we're mapping a node to start looking for children.
+        $voteFieldInfo = Hash::get($event->feed, 'fieldMapping.vote');
+
+        // If there's no mapping for votes, stop here.
+        if (empty($voteFieldInfo)) {
+            return;
+        }
+
+        $fieldData = [];
+
+        foreach ($event->feedData as $nodePath => $value) {
+            $fieldMapping = $this->_getFieldMappingInfoForNodePath($nodePath, $voteFieldInfo);
+
+            if($fieldMapping) {
+                $fieldHandle = $fieldMapping['fieldHandle'];
+                $fieldInfo = $fieldMapping['fieldInfo'];
+
+                $nodePathSegments = explode('/', $nodePath);
+
+                $blockIndex = 0;
+                $nodePathSegments = array_reverse($nodePathSegments);
+                foreach ($nodePathSegments as $segment) {
+                    if(is_numeric($segment)) {
+                        $blockIndex = $segment;
+                        break;
+                    }
+                }
+
+                $key = $blockIndex . '.' . $fieldHandle;
+
+                $fieldInfo['node'] = $nodePath;
+
+                // Parse field values
+                switch ($fieldHandle) {
+                    case 'date':
+                        $value = $this->fetchSimpleValue($event->feedData, $fieldInfo);
+                        $formatting = Hash::get($fieldInfo, 'options.match');
+
+                        $parsedValue = $this->parseDateAttribute($value, $formatting);
+                        break;
+                    case 'userId':
+                        $parsedValue = $this->parseUserId($event->feedData, $fieldInfo);
+                        break;
+                    default:
+                        $parsedValue = $this->fetchSimpleValue($event->feedData, $fieldInfo);
+                        break;
+                }
+                
+                $fieldData[$key] = $parsedValue;
+            }
+
+        }
+
+        ksort($fieldData, SORT_NUMERIC);
+
+        $results = Hash::expand($fieldData);
+
+        // Clear existing votes for this comment
+        Craft::$app->getDb()->createCommand()
+            ->delete('{{%comments_votes}}', ['commentId' => $parentId])
+            ->execute();
+
+        
+        // If there are no votes to import, stop here
+        if(empty($results)) {
+            return;
+        }
+
+        // Fill missing fields with default or empty values
+        $fullResults = [];
+        foreach ($results as $result) {
+            foreach ($voteFieldInfo as $handle => $info) {
+                if(!isset($result[$handle])) {
+                    $result[$handle] = $info['default'] ?? '';
+                }
+            }
+            $fullResults[] = $result;
+        }
+
+        // Save the votes
+        $voteService = Comments::$plugin->getVotes();
+        foreach ($fullResults as $voteData) {
+            $voteRecord = new VoteRecord();
+
+            $voteRecord->commentId = $parentId;
+            $voteRecord->userId = $voteData['userId'] ?? null;
+            $voteRecord->sessionId = $voteService->generateSessionId();
+            $voteRecord->upvote = ($voteData['type'] === 'up') ? 1 : null;;
+            $voteRecord->downvote = ($voteData['type'] === 'down') ? 1 : null;
+            $voteRecord->dateCreated = $voteData['date'] ?? null;;
+
+            if (Craft::$app->getConfig()->getGeneral()->storeUserIps) {
+                $voteRecord->lastIp = $voteData['ipAddress'] ?? null;
+            }
+
+            $voteRecord->save(false);
+        }
+    }
+
     private function _processNestedComments($event): void
     {
         // Save the imported comment as the parent, we'll need it in a sec
@@ -253,4 +359,31 @@ class CommentFeedMeElement extends Element
             Plugin::$plugin->getProcess()->processFeed(-1, $event->feed, $processedElementIds, $newFeedData);
         }
     }
+
+
+    /**
+     * @param $nodePath
+     * @param $fields
+     * @return array|null
+     */
+    private function _getFieldMappingInfoForNodePath($nodePath, $fields): ?array
+    {
+        $feedPath = preg_replace('/(\/\d+\/)/', '/', $nodePath);
+        $feedPath = preg_replace('/^(\d+\/)|(\/\d+)/', '', $feedPath);
+
+        foreach ($fields as $fieldHandle => $fieldInfo) {
+            $node = Hash::get($fieldInfo, 'node');
+
+            if ($feedPath == $node) {
+                return [
+                    'fieldHandle' => $fieldHandle,
+                    'fieldInfo' => $fieldInfo,
+                    'nodePath' => $nodePath
+                ];
+            }
+        }
+
+        return null;
+    }
+    
 }

--- a/src/templates/_integrations/feed-me/map.html
+++ b/src/templates/_integrations/feed-me/map.html
@@ -148,6 +148,72 @@
     </table>
 {% endfor %}
 
+{% set voteFields = [{
+    name: 'Type',
+    handle: 'type',
+    instructions: 'Choose the type of this vote.'|t('feed-me'),
+    default: {
+        type: 'select',
+        options: [
+            { label: 'Don’t import'|t('feed-me'), value: '' },
+            { label: 'Upvote', value: 'up' },
+            { label: 'Downvote', value: 'down' },
+        ],
+    },
+}, {
+    type: 'date',
+    name: 'Vote Date',
+    handle: 'date',
+    instructions: 'Accepts Unix timestamp, or just about any English textual datetime description.'|t('feed-me'),
+    default: {
+        type: 'dateTime',
+    },
+}, {
+    name: 'IP Address',
+    skip: not craft.app.config.getGeneral().storeUserIps,
+    handle: 'ipAddress',
+    default: {
+        type: 'text',
+    },
+}, {
+    type: 'users',
+    name: 'User',
+    handle: 'userId',
+    instructions: 'Vote will be assigned to the user in this field. If the field does not match any existing member, the default user will be assigned.'|t('feed-me'),
+    default: {
+        type: 'elementselect',
+        options: {
+            elementType: 'craft\\elements\\User',
+            selectionLabel: "Default User"|t('feed-me'),
+            limit: 1,
+        },
+    },
+}] %}
+
+<h2>Votes</h2>
+<p>{{ "When updating an extisting comment and one or more of the vote fields are matched with a feed element, all existing votes for the imported comment will be removed before importing the new votes."|t('feed-me') }}</p>
+<table class="feedme-mapping data fullwidth collapsible">
+    <thead>
+        <th>{{ 'Field'|t('feed-me') }}</th>
+        <th>{{ 'Feed Element'|t('feed-me') }}</th>
+        <th>{{ 'Default Value'|t('feed-me') }}</th>
+    </thead>
+    <tbody>
+        {% for field in voteFields %}
+            {% if field.skip is not defined or not field.skip %}
+                {% set template = field.type ?? 'default' %}
+                {% set parentPath = ['vote']|merge ([field.handle]) %}
+                {% set variables = field | merge({ path: parentPath, feed: feed, feedData: feedData, attribute: true }) %}
+
+                {% include [
+                    'comments/_integrations/feed-me/fields/' ~ template,
+                    'feed-me/_includes/fields/' ~ template
+                ] ignore missing with variables only %}
+            {% endif %}
+        {% endfor %}
+    </tbody>
+</table>
+
 <hr>
 
 <h2 id="comment-uniques-label">{{ "Set a unique identifier to match against existing elements" | t('feed-me') }}</h2>


### PR DESCRIPTION
Hey again!
This PR adds support for importing comment votes to the Feed Me integration.

An example import feed (JSON) would look like this:
```json
{
  "comments": [
    {
      "comment": "Example comment",
      "author": 123,
      "votes": [
        {
          "type": "up",
          "user": 456,
          "date": 1690206345
        },
        {
          "type": "down",
          "user": 789,
          "date": 1690206378
        }
      ]
    }
   ]
}
```

Importing the `lastIp` value of a vote is also possible when `storeUserIps` is set to `true`.

When updating an existing comment while the vote fields are mapped in the feed will remove all exising votes from the comment before importing the new ones. When the vote fields are not mapped, existing votes will be preserved. 