### PR TITLE
GraphQL: Fix returning Vote user

### DIFF
--- a/src/gql/interfaces/Vote.php
+++ b/src/gql/interfaces/Vote.php
@@ -93,7 +93,7 @@ class Vote extends InterfaceType
         }
 
         if (GqlHelper::canQueryComments()) {
-            $conditionalFields = array_merge([
+            $conditionalFields = array_merge($conditionalFields, [
                 'commentId' => [
                     'name' => 'commentId',
                     'type' => Type::id(),


### PR DESCRIPTION
When both querying Users and Comments is allowed, the votes did not return user data in GraphQL