### PR TITLE
Fix incorrect Unauthorized error caused by checking against random user

### DIFF
--- a/src/elements/Comment.php
+++ b/src/elements/Comment.php
@@ -832,7 +832,7 @@ class Comment extends Element
                 }
 
                 // Are they a guest trying to comment using a users details?
-                if (!$this->userId) {
+                if (!$this->userId && !empty($this->email)) {
                     $matchedUser = User::find()->email($this->email)->status(null)->one();
 
                     if ($matchedUser) {


### PR DESCRIPTION
When a comment form does not provide an email address, the validation logic is running into the check if a guest user is trying to impersonate an existing, registered user by using their email.

If `$this->email` is `null`, `User::find()` will return a random user from the database (most probably the one with the highest ID, haven't checked). The desired outcome though would be to return none, this is not working because the `->email()` condition is basically omitted and the query will be equal to `User::find()->status(null)->one()`, always returning _**something**_.

This leads to an `Unauthorized` error and failure to save comments for unauthenticated guest users when no email is provided.

This one took me a while 😅 

A simple check to see if the email is actually defined solves this issue.